### PR TITLE
utils: remove tests params and parametrize

### DIFF
--- a/olot/backend/oras_cp.py
+++ b/olot/backend/oras_cp.py
@@ -18,7 +18,7 @@ def oras_pull(base_image: str, dest: typing.Union[str, os.PathLike]):
 
 
 
-def oras_push(src: typing.Union[str, os.PathLike], oci_ref: str):
+def oras_push(src: typing.Union[str, os.PathLike], oci_ref: str, params: typing.Sequence[str]=[]):
     if isinstance(src, os.PathLike):
         src = str(src)
-    return subprocess.run(["oras", "copy", "--from-oci-layout", "--to-plain-http", src+":latest", oci_ref], check=True)
+    return subprocess.run(["oras", "copy", "--from-oci-layout", *params, src+":latest", oci_ref], check=True)

--- a/olot/backend/skopeo.py
+++ b/olot/backend/skopeo.py
@@ -13,7 +13,7 @@ def skopeo_pull(base_image: str, dest: typing.Union[str, os.PathLike]):
     return subprocess.run(["skopeo", "copy", "--multi-arch", "all", "--remove-signatures", "docker://"+base_image, "oci:"+dest+":latest"], check=True)
 
 
-def skopeo_push(src: typing.Union[str, os.PathLike], oci_ref: str):
+def skopeo_push(src: typing.Union[str, os.PathLike], oci_ref: str, params: typing.Sequence[str]=[]):
     if isinstance(src, os.PathLike):
         src = str(src)
-    return subprocess.run(["skopeo", "copy", "--multi-arch", "all", "--dest-tls-verify=false", "oci:"+src+":latest", "docker://"+oci_ref], check=True)
+    return subprocess.run(["skopeo", "copy", "--multi-arch", "all", *params, "oci:"+src+":latest", "docker://"+oci_ref], check=True)

--- a/tests/backend/test_oras_cp.py
+++ b/tests/backend/test_oras_cp.py
@@ -45,7 +45,7 @@ def test_oras_scenario(tmp_path):
     ]
 
     oci_layers_on_top(tmp_path, model_files)
-    oras_push(tmp_path, "localhost:5001/nstestorg/modelcar:latest")
+    oras_push(tmp_path, "localhost:5001/nstestorg/modelcar:latest", ["--to-plain-http"])
 
     # show what has been copied in Container Registry
     subprocess.run(["skopeo","list-tags","--tls-verify=false","docker://localhost:5001/nstestorg/modelcar"], check=True)
@@ -100,7 +100,7 @@ def test_oras_scenario_modelcard(tmp_path):
     ]
 
     oci_layers_on_top(tmp_path, model_files, modelcard)
-    oras_push(tmp_path, "localhost:5001/nstestorg/modelcar:latest")
+    oras_push(tmp_path, "localhost:5001/nstestorg/modelcar:latest", ["--to-plain-http"])
 
     # show what has been copied in Container Registry
     subprocess.run(["skopeo","list-tags","--tls-verify=false","docker://localhost:5001/nstestorg/modelcar"], check=True)

--- a/tests/backend/test_skopeo.py
+++ b/tests/backend/test_skopeo.py
@@ -45,7 +45,7 @@ def test_skopeo_scenario(tmp_path):
     ]
 
     oci_layers_on_top(tmp_path, model_files)
-    skopeo_push(tmp_path, "localhost:5001/nstestorg/modelcar")
+    skopeo_push(tmp_path, "localhost:5001/nstestorg/modelcar", ["--dest-tls-verify=false"])
 
     # show what has been copied in Container Registry
     subprocess.run(["skopeo","list-tags","--tls-verify=false","docker://localhost:5001/nstestorg/modelcar"], check=True)
@@ -100,7 +100,7 @@ def test_skopeo_scenario_modelcard(tmp_path):
     ]
 
     oci_layers_on_top(tmp_path, model_files, modelcard)
-    skopeo_push(tmp_path, "localhost:5001/nstestorg/modelcar")
+    skopeo_push(tmp_path, "localhost:5001/nstestorg/modelcar", ["--dest-tls-verify=false"])
 
     # show what has been copied in Container Registry
     subprocess.run(["skopeo","list-tags","--tls-verify=false","docker://localhost:5001/nstestorg/modelcar"], check=True)


### PR DESCRIPTION
this removes hard coded params used during testing and make them parametric to be passed down
to each backend CLI util

Please note: used intentionally to avoid varargs and rely on a list of str to be simply passed down.