### PR TITLE
core: refactor --remove-originals for strategies

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -106,3 +106,75 @@ jobs:
     - name: Run E2E tests
       run: |
         make test-e2e-oras
+  e2e-remove-originals-cli:
+    name: E2E test remove-originals scenario from CLI
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Skopeo
+      run: |
+        sudo apt-get update && sudo apt-get install skopeo
+        skopeo --version
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9' 
+    - name: Install Poetry
+      run: |
+        pipx install poetry
+    - name: Install dependencies
+      run: |
+        make install
+    - name: Run OLOT tutorial of README, and load image in KinD for amd64
+      run: | 
+        IMAGE_DIR=download
+        OCI_REGISTRY_SOURCE=quay.io/mmortari/hello-world-wait:latest
+        OCI_REGISTRY_DESTINATION=localhost:5001/nstestorg/modelcar
+        rm -rf $IMAGE_DIR
+        skopeo copy --multi-arch all docker://${OCI_REGISTRY_SOURCE} oci:${IMAGE_DIR}:latest
+
+        tmp_dir=$(mktemp -d)
+        echo "*** no-flag scenario using $tmp_dir"
+        cp tests/data/sample-model/README.md "$tmp_dir"
+        cp tests/data/sample-model/model.joblib "$tmp_dir"
+        ls -la "$tmp_dir"
+        poetry run olot $IMAGE_DIR --modelcard "$tmp_dir"/README.md "$tmp_dir"/model.joblib
+        fc=$(find "$tmp_dir" -maxdepth 1 -type f | wc -l)
+        if [ "$fc" -ne 2 ]; then
+          echo "Expected all 2 files remaining, found:"
+          find "$tmp_dir" -maxdepth 1 -type f
+          exit 1
+        fi
+        echo "resulting in:"
+        ls -la "$tmp_dir"
+
+        tmp_dir=$(mktemp -d)
+        echo "*** --remove-originals scenario using $tmp_dir"
+        cp tests/data/sample-model/README.md "$tmp_dir"
+        cp tests/data/sample-model/model.joblib "$tmp_dir"
+        ls -la "$tmp_dir"
+        poetry run olot $IMAGE_DIR --remove-originals --modelcard "$tmp_dir"/README.md "$tmp_dir"/model.joblib
+        fc=$(find "$tmp_dir" -maxdepth 1 -type f | wc -l)
+        if [ "$fc" -ne 1 ]; then
+          echo "Expected only Model CarD remaining, found:"
+          find "$tmp_dir" -maxdepth 1 -type f
+          exit 1
+        fi
+        echo "resulting in:"
+        ls -la "$tmp_dir"
+
+        tmp_dir=$(mktemp -d)
+        echo "*** --remove-originals=all scenario using $tmp_dir"
+        cp tests/data/sample-model/README.md "$tmp_dir"
+        cp tests/data/sample-model/model.joblib "$tmp_dir"
+        ls -la "$tmp_dir"
+        poetry run olot $IMAGE_DIR --remove-originals all --modelcard "$tmp_dir"/README.md "$tmp_dir"/model.joblib
+        fc=$(find "$tmp_dir" -maxdepth 1 -type f | wc -l)
+        if [ "$fc" -ne 0 ]; then
+          echo "Expected none file remaining, found:"
+          find "$tmp_dir" -maxdepth 1 -type f
+          exit 1
+        fi
+        echo "resulting in:"
+        ls -la "$tmp_dir"

--- a/olot/cli.py
+++ b/olot/cli.py
@@ -2,14 +2,14 @@ from os import PathLike
 import click
 import logging
 
-from .basics import oci_layers_on_top
+from .basics import RemoveOriginals, oci_layers_on_top
 
 
 @click.command()
 @click.option("-m", "--modelcard", type=click.Path(exists=True, file_okay=True, dir_okay=False))
 @click.argument('ocilayout', type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @click.argument('model_files', nargs=-1)
-@click.option('-r', '--remove-originals', is_flag=True)
+@click.option('-r', '--remove-originals', type=click.Choice([e.value for e in RemoveOriginals], case_sensitive=False), is_flag=False, flag_value=RemoveOriginals.DEFAULT)
 def cli(ocilayout: str, modelcard: PathLike, model_files, remove_originals: bool):
     logging.basicConfig(level=logging.INFO)
-    oci_layers_on_top(ocilayout, model_files, modelcard, remove_originals=remove_originals)
+    oci_layers_on_top(ocilayout, model_files, modelcard, remove_originals=RemoveOriginals(remove_originals) if remove_originals else None)


### PR DESCRIPTION
support removal of just model weights, config, etc or including Model CarD

Resolves #48 
Opting to refactor the original flag without having to introduce new ones