### PR TITLE
Ensure dependencies are installed before running e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
         skopeo inspect --tls-verify=false docker://${OCI_REGISTRY_DESTINATION}@$digest --raw | jq -e '.layers | last | has("annotations")'
         # tag amd64 as modelcar:v1 and load image in KinD cluster
         skopeo copy --src-tls-verify=false docker://localhost:5001/nstestorg/modelcar@$digest docker-daemon:localhost:5001/nstestorg/modelcar:v1
-        kind load docker-image -n "kind" "localhost:5001/nstestorg/modelcar:v1"
+        kind load docker-image -n "olot-e2e" "localhost:5001/nstestorg/modelcar:v1"
     - name: Apply Isvc using Modelcar # since the enable modelcar restart controller pod, better guard the kubectl apply
       run: |
         e2e/repeat.sh kubectl apply -f e2e/isvc-modelcar.yaml
@@ -83,7 +83,7 @@ jobs:
         skopeo inspect --tls-verify=false docker://${OCI_REGISTRY_DESTINATION}@$digest --raw | jq -e '.layers | last | has("annotations")'
         # tag amd64 as modelcar2:v2 and load image in KinD cluster
         skopeo copy --src-tls-verify=false docker://localhost:5001/nstestorg/modelcar2@$digest docker-daemon:localhost:5001/nstestorg/modelcar2:v2
-        kind load docker-image -n "kind" "localhost:5001/nstestorg/modelcar2:v2"
+        kind load docker-image -n "olot-e2e" "localhost:5001/nstestorg/modelcar2:v2"
     - name: Apply Isvc using Modelcar # since the enable modelcar restart controller pod, better guard the kubectl apply
       run: |
         kubectl patch isvc/my-inference-service \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,13 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         make install
-    - name: Start Kind Cluster
-      uses: helm/kind-action@v1
-      with:
-        cluster_name: kind
-    - name: Start distribution-registry
-      run: |
-        ./e2e/deploy_distribution_registry.sh
     - name: Run E2E tests
       run: |
         make test-e2e-skopeo
@@ -130,13 +123,6 @@ jobs:
     - name: Install dependencies
       run: |
         make install
-    - name: Start Kind Cluster
-      uses: helm/kind-action@v1
-      with:
-        cluster_name: kind
-    - name: Start distribution-registry
-      run: |
-        ./e2e/deploy_distribution_registry.sh
     - name: Run E2E tests
       run: |
         make test-e2e-oras

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,24 @@ install:
 build: install
 	poetry build
 
+.PHONY: deploy-kind-cluster
+deploy-kind-cluster:
+	LOCAL=1 ./e2e/deploy_kind_cluster.sh
+
+.PHONY: deploy-local-registry
+deploy-local-registry:
+	./e2e/deploy_distribution_registry.sh
+
 .PHONY: test
 test:
 	poetry run pytest -s -x -rA
 
 .PHONY: test-e2e-skopeo
-test-e2e-skopeo:
+test-e2e-skopeo: deploy-kind-cluster deploy-local-registry
 	poetry run pytest --e2e-skopeo -s -x -rA
 
 .PHONY: test-e2e-oras
-test-e2e-oras:
+test-e2e-oras: deploy-kind-cluster deploy-local-registry
 	poetry run pytest --e2e-oras -s -x -rA
 
 .PHONY: lint

--- a/e2e/deploy_kind_cluster.sh
+++ b/e2e/deploy_kind_cluster.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [[ -n "$LOCAL" ]]; then
     CLUSTER_NAME="${CLUSTER_NAME:-olot-e2e}"

--- a/e2e/deploy_kind_cluster.sh
+++ b/e2e/deploy_kind_cluster.sh
@@ -1,0 +1,14 @@
+
+if [[ -n "$LOCAL" ]]; then
+    CLUSTER_NAME="${CLUSTER_NAME:-olot-e2e}"
+
+    echo 'Creating local Kind cluster for E2E testing...'
+
+    if [[ $(kind get clusters || false) =~ $CLUSTER_NAME ]]; then
+        echo 'Cluster already exists, skipping creation'
+
+        kubectl config use-context "kind-$CLUSTER_NAME"
+    else
+        kind create cluster -n "$CLUSTER_NAME"
+    fi
+fi


### PR DESCRIPTION
When running the E2E tests, you need to ensure you:

a) Have a kind cluster (or some other local cluster) already running
b) Have a local docker registry running in that kind cluster, with the port forwarded.

This PR just automates that process as a part of running the `make test-e2e-skopeo` and `make test-e2e-oras` tests