### PR TITLE
cli: add --root-dir flag to preserve subdirectory structure

### DIFF
--- a/olot/cli.py
+++ b/olot/cli.py
@@ -9,9 +9,10 @@ from .basics import RemoveOriginals, oci_layers_on_top
 @click.option("-m", "--modelcard", type=click.Path(exists=True, file_okay=True, dir_okay=False), help="file to be used for ModelCarD; if provided, make sure it's not part of [MODEL_FILES] arguments to avoid redundancies.")
 @click.option("--add-modelpack", is_flag=True)
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output (DEBUG level logging)")
+@click.option("--root-dir", type=click.Path(exists=True, file_okay=False, dir_okay=True), default=None, help="root directory of the model files. When provided, each file's path relative to ROOT_DIR is used to preserve its subdirectory structure inside the OCI layer (e.g. a file at ROOT_DIR/onnx/model.onnx is stored as /models/onnx/model.onnx). Without it, only the file's basename is used, so files with the same name in different subdirectories will collide and overwrite each other.")
 @click.argument('ocilayout', type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @click.argument('model_files', nargs=-1)
 @click.option('-r', '--remove-originals', type=click.Choice([e.value for e in RemoveOriginals], case_sensitive=False), is_flag=False, flag_value=RemoveOriginals.DEFAULT)
-def cli(ocilayout: str, modelcard: PathLike, model_files, remove_originals: bool, add_modelpack: bool, verbose: bool):
+def cli(ocilayout: str, modelcard: PathLike, model_files, remove_originals: bool, add_modelpack: bool, verbose: bool, root_dir: PathLike):
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
-    oci_layers_on_top(ocilayout, model_files, modelcard, remove_originals=RemoveOriginals(remove_originals) if remove_originals else None, add_modelpack=add_modelpack)
+    oci_layers_on_top(ocilayout, model_files, modelcard, root_dir=root_dir, remove_originals=RemoveOriginals(remove_originals) if remove_originals else None, add_modelpack=add_modelpack)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,88 @@
+import shutil
+import tarfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from olot.cli import cli
+from tests.common import get_test_data_path
+
+
+def test_cli_root_dir_preserves_nested_paths(tmp_path: Path):
+    """--root-dir should preserve subdirectory structure for CLI invocations,
+    so files with the same basename in different subdirectories don't collide
+    (e.g. config.json at the model root vs. inference/config.json).
+    """
+    test_ocilayout5 = get_test_data_path() / "ocilayout5"
+    target_ocilayout = tmp_path / "myocilayout"
+    shutil.copytree(test_ocilayout5, target_ocilayout)
+
+    model_dir = tmp_path / "my-model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"top": true}')
+    inference_dir = model_dir / "inference"
+    inference_dir.mkdir()
+    (inference_dir / "config.json").write_text('{"inference_only": true}')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--root-dir", str(model_dir),
+            str(target_ocilayout),
+            str(model_dir / "config.json"),
+            str(inference_dir / "config.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    all_archive_paths: list[str] = []
+    blobs_dir = target_ocilayout / "blobs" / "sha256"
+    for blob in blobs_dir.iterdir():
+        try:
+            with tarfile.open(str(blob), "r") as tar:
+                all_archive_paths.extend(m.name for m in tar.getmembers() if not m.isdir())
+        except tarfile.ReadError:
+            continue
+
+    assert "models/config.json" in all_archive_paths
+    assert "models/inference/config.json" in all_archive_paths
+
+
+def test_cli_without_root_dir_flattens_paths(tmp_path: Path):
+    """Without --root-dir, the CLI keeps its existing flat behavior: only the
+    file's basename is used, so same-named files in different directories
+    collide on the same archive path.
+    """
+    test_ocilayout5 = get_test_data_path() / "ocilayout5"
+    target_ocilayout = tmp_path / "myocilayout"
+    shutil.copytree(test_ocilayout5, target_ocilayout)
+
+    model_dir = tmp_path / "my-model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"top": true}')
+    inference_dir = model_dir / "inference"
+    inference_dir.mkdir()
+    (inference_dir / "config.json").write_text('{"inference_only": true}')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            str(target_ocilayout),
+            str(model_dir / "config.json"),
+            str(inference_dir / "config.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    all_archive_paths: list[str] = []
+    blobs_dir = target_ocilayout / "blobs" / "sha256"
+    for blob in blobs_dir.iterdir():
+        try:
+            with tarfile.open(str(blob), "r") as tar:
+                all_archive_paths.extend(m.name for m in tar.getmembers() if not m.isdir())
+        except tarfile.ReadError:
+            continue
+
+    assert all_archive_paths.count("models/config.json") == 2


### PR DESCRIPTION
## Summary

`oci_layers_on_top` already supports a `root_dir` parameter (see `olot/basics.py`, added for exactly this purpose) that preserves each file's subdirectory structure relative to `root_dir` when computing its in-layer archive path (e.g. a file at `ROOT_DIR/onnx/model.onnx` is stored as `/models/onnx/model.onnx`).

However, the CLI had no way to pass this through. CLI callers were stuck with the flat fallback behavior: the in-layer path is derived from each file's **basename alone**, so files with the same name in different subdirectories (e.g. a top-level `config.json` and a nested `inference/config.json`) collide on the same in-layer path and silently overwrite each other.

This surfaced as a real production bug in a Konflux pipeline: a large model with both a root `config.json` and a nested `inference/config.json` was processed via a batched `olot` CLI invocation (one file per batch, since the whole model doesn't fit in a single pass), and the wrong `config.json` ended up in the final image, breaking vLLM at load time (`Unrecognized model in /mnt/models. Should have a model_type key in its config.json`).

- Adds `--root-dir` to the CLI, wired through to `oci_layers_on_top`'s existing `root_dir` parameter.
- No changes to default/flat behavior when `--root-dir` isn't passed.
