### PR TITLE
fix: use GNU tar format so Clair can scan layers >8GiB

### DIFF
--- a/olot/utils/files.py
+++ b/olot/utils/files.py
@@ -127,7 +127,9 @@ def tarball_from_file(file_path: Path, dest: Path, prefix: str = "/models/") -> 
         input_type = LayerInputType.DIRECTORY
         with open(temp_dest, "wb") as temp_file:
             writer = HashingWriter(temp_file)
-            with tarfile.open(fileobj=writer, mode="w") as tar: # type: ignore[call-overload]
+            # GNU_FORMAT: Clair tarfs ignores PAX size= attrs; files >8GiB need
+            # the binary size in the ustar header or Clair fails with bad block.
+            with tarfile.open(fileobj=writer, mode="w", format=tarfile.GNU_FORMAT) as tar: # type: ignore[call-overload]
                 if file_path.is_file():
                     with open(file_path, 'rb') as f:
                         hashing_reader = HashingFileReader(f)
@@ -184,7 +186,8 @@ def targz_from_file(file_path: Path, dest: Path, prefix: str = "/models/") -> La
             writer = HashingWriter(temp_file)
             with gzip.GzipFile(fileobj=writer, mode="wb", mtime=0, compresslevel=6) as gz: # type: ignore[call-overload]
                 inner_writer = HashingWriter(gz)
-                with tarfile.open(fileobj=inner_writer, mode="w") as tar: # type: ignore[call-overload]
+                # GNU_FORMAT: see tarball_from_file — Clair needs ustar size for >8GiB files.
+                with tarfile.open(fileobj=inner_writer, mode="w", format=tarfile.GNU_FORMAT) as tar: # type: ignore[call-overload]
                     if file_path.is_file():
                         with open(file_path, 'rb') as f:
                             hashing_reader = HashingFileReader(f)

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,7 +25,7 @@ def file_checksums_without_compression(source_file: Path, tmp_dest: Path) -> str
 
     with open(temp_tar_filename, "wb") as temp_file:
         writer = HashingWriter(temp_file)
-        with tarfile.open(fileobj=writer, mode="w") as tar: # type: ignore[call-overload]
+        with tarfile.open(fileobj=writer, mode="w", format=tarfile.GNU_FORMAT) as tar: # type: ignore[call-overload]
             tar.add(source_file, arcname="/models/"+source_file.name, filter=tar_filter_fn)
     sha = get_file_hash(temp_tar_filename)
     shutil.rmtree(tmp_dest)
@@ -39,13 +39,13 @@ def file_checksums_with_compression(source_file: Path, tmp_dest: Path) -> tuple[
         writer = HashingWriter(temp_file)
         with gzip.GzipFile(fileobj=writer, mode="wb", mtime=0, compresslevel=6) as gz: # type: ignore[call-overload]
             inner_writer = HashingWriter(gz)
-            with tarfile.open(fileobj=inner_writer, mode="w") as tar: # type: ignore[call-overload]
+            with tarfile.open(fileobj=inner_writer, mode="w", format=tarfile.GNU_FORMAT) as tar: # type: ignore[call-overload]
                 tar.add(source_file, arcname="/models/"+source_file.name, filter=tar_filter_fn)
 
     postcompress_chksum_from_disk = get_file_hash(temp_tar_filename)
 
     uncompressed_tar = tmp_dest / "uncompressed.tar"
-    with tarfile.open(uncompressed_tar, mode="w") as tar: # type: ignore[call-overload]
+    with tarfile.open(uncompressed_tar, mode="w", format=tarfile.GNU_FORMAT) as tar: # type: ignore[call-overload]
         tar.add(source_file, arcname=source_file.name)
     uncompressed_checksum_from_disk = get_file_hash(uncompressed_tar)
 

--- a/tests/utils/files_test.py
+++ b/tests/utils/files_test.py
@@ -119,6 +119,40 @@ def test_tarball_from_file(tmp_path):
     assert found
 
 
+def test_tarball_gnu_format_clair_compat_large_file_size():
+    """Clair tarfs ignores PAX size= attrs; >8GiB files need GNU binary size in the ustar header.
+
+    Without GNU_FORMAT, Python's default PAX leaves ustar size=0 for files >8GiB and Clair
+    fails with: tarfs: error finding segments: bad block at 1536
+    """
+    info = tarfile.TarInfo(name="/models/model-00001-of-00002.safetensors")
+    info.size = 9 * 1024**3  # >8GiB
+    info.uid = 0
+    info.gid = 0
+    info.mode = 0o664
+
+    # PAX (Python default): file header at block 2 has size=0 — Clair would mis-parse.
+    pax = info.tobuf(tarfile.PAX_FORMAT, "utf-8")
+    assert len(pax) == 1536
+    assert pax[1024 + 124 : 1024 + 136] == b"00000000000\x00"
+
+    # GNU: size is binary-encoded in the ustar header (high bit set) — Clair parseNumber handles this.
+    gnu = info.tobuf(tarfile.GNU_FORMAT, "utf-8")
+    assert len(gnu) == 512
+    assert gnu[257:263] == b"ustar "  # GNU magic
+    assert gnu[124] & 0x80  # binary size field
+
+
+def test_tarball_from_file_writes_gnu_magic(tmp_path):
+    """Layers written by tarball_from_file must use GNU ustar magic for Clair compatibility."""
+    model_path = sample_model_path() / "model.joblib"
+    write_dest = sha256_path(tmp_path)
+    write_dest.mkdir(parents=True, exist_ok=True)
+    digest = tarball_from_file(model_path, write_dest).layer_digest
+    raw = (write_dest / digest).read_bytes()
+    assert raw[257:263] == b"ustar "
+
+
 def test_tarball_from_file_using_prefix(tmp_path):
     """Test tarball_from_file() function is able to produce the expected tar (uncompressed) layer blob in the oci-layout
     but providing a custom prefix location for the file.


### PR DESCRIPTION
## Summary
- Force `tarfile.GNU_FORMAT` when writing model layers (`tarball_from_file` / `targz_from_file`).
- Fixes Clair scan failures on ModelCars with weight files >8GiB (e.g. gemma-4-26b shard ~46GiB), where Python's default PAX format leaves ustar `size=0` and Clair's tarfs reports `bad block at 1536`.
- Adds regression tests for GNU magic and >8GiB size encoding.

## Test plan
- [x] `uv run pytest tests/utils/files_test.py tests/oci/oci_artifact_test.py tests/basic_test.py`