### PR TITLE
fix: explicit UTF-8 encoding when writing JSON

### DIFF
--- a/olot/basics.py
+++ b/olot/basics.py
@@ -141,7 +141,7 @@ def oci_layers_on_top(
         logger.debug("manifest_hash: %s, manifest.mediaType: %s", manifest_hash, manifest.mediaType)
         config_sha = manifest.config.digest.removeprefix("sha256:")
         mc = None
-        with open(ocilayout / "blobs" / "sha256" / config_sha, "r") as cf:
+        with open(ocilayout / "blobs" / "sha256" / config_sha, "r") as cf:  # noqa: PLW1514
             mc = OCIManifestConfig.model_validate_json(cf.read())
             if mc.history is None:
                 mc.history = []
@@ -186,7 +186,7 @@ def oci_layers_on_top(
                 mc.config.Labels.update(labels)
         # save the OCI Image Config
         mc_json = mc.model_dump_json(exclude_none=True)
-        with open(ocilayout / "blobs" / "sha256" / config_sha, "w") as cf:
+        with open(ocilayout / "blobs" / "sha256" / config_sha, "w", encoding="utf-8") as cf:
             cf.write(mc_json)
         mc_json_hash = compute_hash_of_str(mc_json)
         os.rename(ocilayout / "blobs" / "sha256" / config_sha, ocilayout / "blobs" / "sha256" / mc_json_hash)
@@ -204,7 +204,7 @@ def oci_layers_on_top(
         check_manifest(manifest, mc)
         # save the OCI Image Manifest
         manifest_json = manifest.model_dump_json(exclude_none=True)
-        with open(ocilayout / "blobs" / "sha256" / manifest_hash, "w") as cf:
+        with open(ocilayout / "blobs" / "sha256" / manifest_hash, "w", encoding="utf-8") as cf:
             cf.write(manifest_json)
         manifest_json_hash = compute_hash_of_str(manifest_json)
         os.rename(ocilayout / "blobs" / "sha256" / manifest_hash, ocilayout / "blobs" / "sha256" / manifest_json_hash)
@@ -244,7 +244,7 @@ def oci_layers_on_top(
                     annotations={"io.opendatahub.author": "olot", "io.opendatahub.modelcar.manifest.type":"modelpack"},
                 ))
         index_json = index.model_dump_json(exclude_none=True)
-        with open(ocilayout / "blobs" / "sha256" / index_hash, "w") as idxf:
+        with open(ocilayout / "blobs" / "sha256" / index_hash, "w", encoding="utf-8") as idxf:
             idxf.write(index_json)
         index_json_hash = compute_hash_of_str(index_json)
         os.rename(ocilayout / "blobs" / "sha256" / index_hash, ocilayout / "blobs" / "sha256" / index_json_hash)
@@ -285,7 +285,7 @@ def oci_layers_on_top(
                 ),
                 annotations={"io.opendatahub.author": "olot", "io.opendatahub.modelcar.manifest.type":"modelpack"},
             ))
-    with open(ocilayout / "index.json", "w") as root_idx_f:
+    with open(ocilayout / "index.json", "w", encoding="utf-8") as root_idx_f:
         root_idx_f.write(ocilayout_root_index.model_dump_json(exclude_none=True))
 
 
@@ -299,7 +299,7 @@ def add_modelpack_manifest(ocilayout: Path, new_layers: dict[str, LayerStats]) -
     )
     model_config_json = model_config.model_dump_json(exclude_none=True)
     model_config_hash = compute_hash_of_str(model_config_json)
-    with open(ocilayout / "blobs" / "sha256" / model_config_hash, "w") as mpcf:
+    with open(ocilayout / "blobs" / "sha256" / model_config_hash, "w", encoding="utf-8") as mpcf:
         mpcf.write(model_config_json)
     cds = []
     for layer in new_layers.values():
@@ -334,7 +334,7 @@ def add_modelpack_manifest(ocilayout: Path, new_layers: dict[str, LayerStats]) -
     )
     manifest_json = manifest.model_dump_json(exclude_none=True)
     manifest_hash = compute_hash_of_str(manifest_json)
-    with open(ocilayout / "blobs" / "sha256" / manifest_hash, "w") as mf:
+    with open(ocilayout / "blobs" / "sha256" / manifest_hash, "w", encoding="utf-8") as mf:
         mf.write(manifest_json)
     return manifest_hash
 
@@ -377,14 +377,14 @@ def crawl_ocilayout_manifests(ocilayout: Path, ocilayout_indexes: dict[str, OCII
             target_hash = m.digest.removeprefix("sha256:")
             logger.debug("target_hash %s", target_hash)
             manifest_path = ocilayout / "blobs" / "sha256" / target_hash
-            with open(manifest_path, "r") as ip:
+            with open(manifest_path, "r") as ip:  # noqa: PLW1514
                 ocilayout_manifests[target_hash] = OCIImageManifest.model_validate_json(ip.read())
     for m in ocilayout_root_index.manifests if ocilayout_root_index is not None else []:
         if m.mediaType == MediaTypes.manifest:
             target_hash = m.digest.removeprefix("sha256:")
             logger.debug("Lookup remainder manifest from ocilayout_root_index having target_hash %s", target_hash)
             manifest_path = ocilayout / "blobs" / "sha256" / target_hash
-            with open(manifest_path, "r") as ip:
+            with open(manifest_path, "r") as ip:  # noqa: PLW1514
                 ocilayout_manifests[target_hash] = OCIImageManifest.model_validate_json(ip.read())
 
     # filter out non-runnable OCI Images, like Vendor'd Attestations format, and log it out
@@ -403,7 +403,7 @@ def write_empty_config_in_ocilayoyt(ocilayout: Path):
     """
     blobs_path = ocilayout / "blobs" / "sha256"
     blobs_path.mkdir(parents=True, exist_ok=True)
-    with open(blobs_path / "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", 'w') as f:
+    with open(blobs_path / "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", 'w', encoding="utf-8") as f:
         f.write("{}")
 
 
@@ -413,7 +413,7 @@ def crawl_ocilayout_indexes(ocilayout: Path, ocilayout_root_index: OCIImageIndex
         if m.mediaType == MediaTypes.index:
             target_hash = m.digest.removeprefix("sha256:")
             index_path = ocilayout / "blobs" / "sha256" / target_hash
-            with open(index_path, "r") as ip:
+            with open(index_path, "r") as ip:  # noqa: PLW1514
                 ocilayout_indexes[target_hash] = OCIImageIndex.model_validate_json(ip.read())
     return ocilayout_indexes
 
@@ -446,7 +446,7 @@ def crawl_ocilayout_blobs_to_extract(ocilayout: Path,
         raise ValueError("Can only extract from ModelCar Image manifests")
     target_hash = manifest0.digest.removeprefix("sha256:")
     manifest_path = blobs_path / target_hash
-    with open(manifest_path, "r") as ip:
+    with open(manifest_path, "r") as ip:  # noqa: PLW1514
         image_manifest = OCIImageManifest.model_validate_json(ip.read())
     for layer in image_manifest.layers:
         if layer.mediaType == MediaTypes.layer or layer.mediaType == MediaTypes.layer_gzip:

--- a/olot/dockerdist/convert.py
+++ b/olot/dockerdist/convert.py
@@ -25,7 +25,7 @@ def check_if_oci_layout_contains_docker_manifests(directory: Path) -> bool:
         if not blob.is_file():  # although not expecting the scenario based on spec.
             continue
         try:
-            with open(blob, 'r') as f:
+            with open(blob, 'r') as f:  # noqa: PLW1514
                 data = json.load(f)
                 if data.get("mediaType") == DOCKER_MANIFEST_V2:
                     return True
@@ -52,7 +52,7 @@ def convert_docker_manifests_to_oci(directory: Path) -> dict[str, str]:
     img_manifest_files = []
     for blob in blobs_path.iterdir():
         try:
-            with open(blob, 'r') as f:
+            with open(blob, 'r') as f:  # noqa: PLW1514
                 data = json.load(f)
                 if data.get("mediaType") == DOCKER_MANIFEST_V2:
                     img_manifest_files.append(blob)
@@ -67,14 +67,14 @@ def convert_docker_manifests_to_oci(directory: Path) -> dict[str, str]:
     list_manifest_files = []
     for blob in blobs_path.iterdir():
         try:
-            with open(blob, 'r') as f:
+            with open(blob, 'r') as f:  # noqa: PLW1514
                 data = json.load(f)
                 if data.get("mediaType") == DOCKER_LIST_V2:
                     list_manifest_files.append(blob)
         except (json.JSONDecodeError, UnicodeDecodeError, OSError):  # not a manifest
             continue
     for blob_file in list_manifest_files:
-        with open(blob_file, 'r') as file_handle:
+        with open(blob_file, 'r') as file_handle:  # noqa: PLW1514
             index = OCIImageIndex.model_validate_json(file_handle.read())
             for manifest in index.manifests:
                 if manifest.mediaType == DOCKER_MANIFEST_V2:
@@ -87,7 +87,7 @@ def convert_docker_manifests_to_oci(directory: Path) -> dict[str, str]:
             index.mediaType = MediaTypes.index
             index_json = index.model_dump_json(exclude_none=True)
             new_index_hash = compute_hash_of_str(index_json)
-            (blobs_path / new_index_hash).write_text(index_json)
+            (blobs_path / new_index_hash).write_text(index_json, encoding="utf-8")
             converted[blob_file.name] = new_index_hash
 
     index = OCIImageIndex.model_validate_json((directory / "index.json").read_text())
@@ -95,11 +95,11 @@ def convert_docker_manifests_to_oci(directory: Path) -> dict[str, str]:
         new_digest = converted[manifest.digest.removeprefix("sha256:")]
         manifest.digest = "sha256:" + new_digest
         manifest.size = os.stat(blobs_path / new_digest).st_size
-        with open(blobs_path / new_digest, 'r') as f:
+        with open(blobs_path / new_digest, 'r') as f:  # noqa: PLW1514
             new_media_type = json.load(f).get("mediaType")
             manifest.mediaType = new_media_type
     new_index_json = index.model_dump_json(exclude_none=True)
-    (directory / "index.json").write_text(new_index_json)
+    (directory / "index.json").write_text(new_index_json, encoding="utf-8")
 
     for from_dd_hash, to_oci_hash in converted.items():
         logger.info("Docker distribution manifest %s is now at OCI manifest %s", from_dd_hash, to_oci_hash)
@@ -107,7 +107,7 @@ def convert_docker_manifests_to_oci(directory: Path) -> dict[str, str]:
 
 
 def convert_docker_manifest_to_oci(manifest_file: Path, directory: Path) -> str:
-    with open(manifest_file, 'r') as f:
+    with open(manifest_file, 'r') as f:  # noqa: PLW1514
         docker_manifest_data = json.load(f)
 
     if docker_manifest_data.get("mediaType") != DOCKER_MANIFEST_V2:
@@ -140,7 +140,7 @@ def convert_docker_manifest_to_oci(manifest_file: Path, directory: Path) -> str:
     if not config_file.exists():
         raise FileNotFoundError(f"Config file not found: {config_file}")
     
-    with open(config_file, 'r') as f:
+    with open(config_file, 'r') as f:  # noqa: PLW1514
         docker_config_data = json.load(f)
 
     oci_config = OCIManifestConfig.model_validate(docker_config_data)
@@ -156,7 +156,7 @@ def convert_docker_manifest_to_oci(manifest_file: Path, directory: Path) -> str:
         data=None,
         artifactType=None
     )
-    (blobs_path / new_config_hash).write_text(oci_config_json)
+    (blobs_path / new_config_hash).write_text(oci_config_json, encoding="utf-8")
 
     oci_manifest = OCIImageManifest(
         schemaVersion=2,
@@ -167,7 +167,7 @@ def convert_docker_manifest_to_oci(manifest_file: Path, directory: Path) -> str:
     )
     oci_manifest_json = oci_manifest.model_dump_json(exclude_none=True)
     oci_manifest_hash = compute_hash_of_str(oci_manifest_json)
-    (blobs_path / oci_manifest_hash).write_text(oci_manifest_json)
+    (blobs_path / oci_manifest_hash).write_text(oci_manifest_json, encoding="utf-8")
 
     return oci_manifest_hash
 

--- a/olot/oci/oci_image_index.py
+++ b/olot/oci/oci_image_index.py
@@ -197,7 +197,7 @@ class OCIImageIndex(BaseModel):
 
 def read_ocilayout_root_index(ocilayout: Path) -> OCIImageIndex:
     ocilayout_root_index = None
-    with open(ocilayout / "index.json", "r") as f:
+    with open(ocilayout / "index.json", "r") as f:  # noqa: PLW1514
         ocilayout_root_index = OCIImageIndex.model_validate_json(f.read())
     return ocilayout_root_index
 

--- a/olot/oci/oci_image_layout.py
+++ b/olot/oci/oci_image_layout.py
@@ -23,7 +23,7 @@ class OCIImageLayout(BaseModel):
         use_enum_values = True
 
 def verify_ocilayout(ocilayout: Path):
-    with open(ocilayout / "oci-layout", "r") as f:
+    with open(ocilayout / "oci-layout", "r") as f:  # noqa: PLW1514
         m = OCIImageLayout.model_validate_json(f.read())
         if not m.imageLayoutVersion == ImageLayoutVersion.field_1_0_0.value:
             raise ValueError(f"Unexpected ocilayout in {ocilayout}")

--- a/olot/oci_artifact.py
+++ b/olot/oci_artifact.py
@@ -55,7 +55,7 @@ def create_oci_artifact_from_model(source_dir: Path, dest_dir: Path):
     )
     manifest_json = json.dumps(manifest.dict(exclude_none=True), indent=4, sort_keys=True)
     manifest_SHA = compute_hash_of_str(manifest_json)
-    with open(sha256_path / manifest_SHA, "w") as f:
+    with open(sha256_path / manifest_SHA, "w", encoding="utf-8") as f:
         f.write(manifest_json)
 
     # Create the OCI image index
@@ -70,19 +70,19 @@ def create_oci_artifact_from_model(source_dir: Path, dest_dir: Path):
         ]
     )
     index_json = json.dumps(index.dict(exclude_none=True), indent=4, sort_keys=True)
-    with open(dest_dir / "index.json", "w") as f:
+    with open(dest_dir / "index.json", "w", encoding="utf-8") as f:
         f.write(index_json)
 
     # Create the OCI-layout file
     oci_layout = create_ocilayout()
-    with open(dest_dir / "oci-layout", "w") as f:
+    with open(dest_dir / "oci-layout", "w", encoding="utf-8") as f:
         f.write(json.dumps(oci_layout.model_dump(), indent=4, sort_keys=True))
 
     # Create empty config file with digest as name
     empty_config: dict[str, str] = {}
     empty_digest_split = Values.empty_digest.split(":")
     if len(empty_digest_split) == 2:
-        with open(dest_dir / "blobs" / "sha256" / empty_digest_split[1], "w") as f:
+        with open(dest_dir / "blobs" / "sha256" / empty_digest_split[1], "w", encoding="utf-8") as f:
             f.write(json.dumps(empty_config))
     else:
         raise ValueError(f"Invalid empty_digest format: {Values.empty_digest}")
@@ -163,7 +163,7 @@ def create_simple_oci_artifact(source_path: Path,
         cds.append(cd)
     mc_json = mc.model_dump_json(exclude_none=True)
     mc_json_hash = compute_hash_of_str(mc_json)
-    (blobs_path / mc_json_hash).write_text(mc_json)
+    (blobs_path / mc_json_hash).write_text(mc_json, encoding="utf-8")
     manifest = create_oci_image_manifest(
         config=ContentDescriptor(
                 mediaType=MediaTypes.config,
@@ -181,10 +181,10 @@ def create_simple_oci_artifact(source_path: Path,
     manifest_json = manifest.model_dump_json(indent=2, exclude_none=True)
     manifest_SHA = compute_hash_of_str(manifest_json)
     manifest_blob_path = blobs_path / manifest_SHA
-    manifest_blob_path.write_text(manifest.model_dump_json(indent=2, exclude_none=True))
+    manifest_blob_path.write_text(manifest.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
     
     layout = OCIImageLayout(imageLayoutVersion=ImageLayoutVersion.field_1_0_0)
-    (oci_layout_path / "oci-layout").write_text(layout.model_dump_json(indent=2, exclude_none=True))
+    (oci_layout_path / "oci-layout").write_text(layout.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")
 
     index = OCIImageIndex(schemaVersion=2,
                           mediaType=MediaTypes.index,
@@ -198,4 +198,4 @@ def create_simple_oci_artifact(source_path: Path,
                           ],
                           artifactType=None,
                           )
-    (oci_layout_path / "index.json").write_text(index.model_dump_json(indent=2, exclude_none=True))
+    (oci_layout_path / "index.json").write_text(index.model_dump_json(indent=2, exclude_none=True), encoding="utf-8")

--- a/olot/utils/types.py
+++ b/olot/utils/types.py
@@ -14,5 +14,5 @@ Annotations = Annotated[MapStringString, Field()]
 
 def compute_hash_of_str(content: str) -> str:
     h = hashlib.sha256()
-    h.update(content.encode())
+    h.update(content.encode("utf-8"))
     return h.hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ target-version = "py310"
 respect-gitignore = true
 
 
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+extend-select = ["PLW1514"]
+
+
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = [
     "E402",

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -183,7 +183,7 @@ def test_write_empty_oci_config(tmp_path: Path):
 
     empty_config_path = oci_layout_path / "blobs" / "sha256" / "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     assert empty_config_path.exists()
-    with open(empty_config_path, "r") as f:
+    with open(empty_config_path, "r") as f:  # noqa: PLW1514
         actual = compute_hash_of_str(f.read())
     assert actual == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
 
@@ -239,7 +239,7 @@ def test_oci_layers_on_top_single_manifest_and_check_annotations(tmp_path: Path)
 
     assert len(manifest0.layers) == 4
     # check manifest.config.history contains the appropriate length
-    with open(target_ocilayout / "blobs" / "sha256" / manifest0.config.digest.removeprefix("sha256:"), "r") as f:
+    with open(target_ocilayout / "blobs" / "sha256" / manifest0.config.digest.removeprefix("sha256:"), "r") as f:  # noqa: PLW1514
         mc = OCIManifestConfig.model_validate_json(f.read())
         assert mc.history
         assert len(mc.history) == 5 # check we preserved also previous history, 2 elements, + 3 new history items for the 3 new layers
@@ -468,7 +468,7 @@ def test_add_labels_and_annotations(tmp_path: Path):
     assert manifest0.annotations
     assert manifest0.annotations["c"] == "d"
     config_digest = manifest0.config.digest.removeprefix("sha256:")
-    with open(target_ocilayout / "blobs" / "sha256" / config_digest, "r") as f:
+    with open(target_ocilayout / "blobs" / "sha256" / config_digest, "r") as f:  # noqa: PLW1514
         mc = OCIManifestConfig.model_validate_json(f.read())
         assert mc.config
         assert mc.config.Labels
@@ -508,12 +508,12 @@ def test_oci_layers_on_top_nested_files(tmp_path: Path, use_root_dir):
     # Create a model dir with nested subdirectories and duplicate filenames
     model_dir = tmp_path / "my-model"
     model_dir.mkdir()
-    (model_dir / "config.json").write_text('{"top": true}')
+    (model_dir / "config.json").write_text('{"top": true}', encoding="utf-8")
     (model_dir / "model.onnx").write_bytes(os.urandom(64))
     onnx_dir = model_dir / "onnx"
     onnx_dir.mkdir()
     (onnx_dir / "model.onnx").write_bytes(os.urandom(128))
-    (onnx_dir / "config.json").write_text('{"onnx": true}')
+    (onnx_dir / "config.json").write_text('{"onnx": true}', encoding="utf-8")
     int8_dir = model_dir / "quantized" / "int8"
     int8_dir.mkdir(parents=True)
     (int8_dir / "model.onnx").write_bytes(os.urandom(96))

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -19,10 +19,10 @@ def test_cli_root_dir_preserves_nested_paths(tmp_path: Path):
 
     model_dir = tmp_path / "my-model"
     model_dir.mkdir()
-    (model_dir / "config.json").write_text('{"top": true}')
+    (model_dir / "config.json").write_text('{"top": true}', encoding="utf-8")
     inference_dir = model_dir / "inference"
     inference_dir.mkdir()
-    (inference_dir / "config.json").write_text('{"inference_only": true}')
+    (inference_dir / "config.json").write_text('{"inference_only": true}', encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -60,10 +60,10 @@ def test_cli_without_root_dir_flattens_paths(tmp_path: Path):
 
     model_dir = tmp_path / "my-model"
     model_dir.mkdir()
-    (model_dir / "config.json").write_text('{"top": true}')
+    (model_dir / "config.json").write_text('{"top": true}', encoding="utf-8")
     inference_dir = model_dir / "inference"
     inference_dir.mkdir()
-    (inference_dir / "config.json").write_text('{"inference_only": true}')
+    (inference_dir / "config.json").write_text('{"inference_only": true}', encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/oci/oci_artifact_test.py
+++ b/tests/oci/oci_artifact_test.py
@@ -89,11 +89,11 @@ def test_full_artifact(tmp_path):
     manifest_json = manifest.model_dump_json(indent=2, exclude_none=True)
     manifest_SHA = compute_hash_of_str(manifest_json)
     manifest_blob_path = blobs_path / manifest_SHA
-    with open(manifest_blob_path, "w") as f:
+    with open(manifest_blob_path, "w", encoding="utf-8") as f:
         f.write(manifest.model_dump_json(indent=2, exclude_none=True))
     
     layout = OCIImageLayout(imageLayoutVersion="1.0.0")
-    with open(ocilayout_path / "oci-layout", "w") as f:
+    with open(ocilayout_path / "oci-layout", "w", encoding="utf-8") as f:
         f.write(layout.model_dump_json(indent=2, exclude_none=True))
 
     index = OCIImageIndex(schemaVersion=2,
@@ -103,7 +103,7 @@ def test_full_artifact(tmp_path):
                                        digest="sha256:"+manifest_SHA,
                                        annotations={"org.opencontainers.image.ref.name": "latest"})
                           ])
-    with open(ocilayout_path / "index.json", "w") as f:
+    with open(ocilayout_path / "index.json", "w", encoding="utf-8") as f:
         f.write(index.model_dump_json(indent=2, exclude_none=True))
 
     # now let's use oras-copy to transfer from oci-layout to another oci-layout (instead of a OCI registry)

--- a/tests/oci/test_oci.py
+++ b/tests/oci/test_oci.py
@@ -16,10 +16,10 @@ def test_non_regression():
     """Given a known oci-layout, smoke test deserialization of OCI "models"
     """
     base_path = Path(__file__).parent / ".." / "data" / "ocilayout1"
-    with open(base_path / "oci-layout", "r") as f:
+    with open(base_path / "oci-layout", "r") as f:  # noqa: PLW1514
         m = OCIImageLayout.model_validate_json(f.read())
         print(m)
-    with open(base_path / "index.json", "r") as f:
+    with open(base_path / "index.json", "r") as f:  # noqa: PLW1514
         m = OCIImageIndex.model_validate_json(f.read())
         print(m)
         print(m.manifests[0].size)
@@ -29,19 +29,19 @@ def test_non_regression():
     ta.validate_python("asd/asd")
 
     write_dest = sha256_path(base_path)
-    with open(write_dest / "db142d433cdde11f10ae479dbf92f3b13d693fd1c91053da9979728cceb1dc68", "r") as f:
+    with open(write_dest / "db142d433cdde11f10ae479dbf92f3b13d693fd1c91053da9979728cceb1dc68", "r") as f:  # noqa: PLW1514
         m = OCIImageIndex.model_validate_json(f.read())
         print(m)
         for manifest in m.manifests:
             print(manifest.platform)
             print(manifest.digest)
 
-    with open(write_dest / "a3e1b257b47c09c9997212e53a0b570c1666501ad26e5bf33461304babab47c7", "r") as f:
+    with open(write_dest / "a3e1b257b47c09c9997212e53a0b570c1666501ad26e5bf33461304babab47c7", "r") as f:  # noqa: PLW1514
         m = OCIImageManifest.model_validate_json(f.read())
         print(m)
         print(m.config.digest)
 
-    with open(write_dest / "517b897a6a8312ce202a85c8a517d820b0fc5b6f5d14ec2a3267906f75680403", "r") as f:
+    with open(write_dest / "517b897a6a8312ce202a85c8a517d820b0fc5b6f5d14ec2a3267906f75680403", "r") as f:  # noqa: PLW1514
         m = OCIManifestConfig.model_validate_json(f.read())
         print(m)
         print(m.rootfs)


### PR DESCRIPTION
The OCI image spec mandates that all JSON content (media types ending in +json) MUST be encoded as UTF-8. This change
adds explicit encoding="utf-8" to every open("w"), Path.write_text(), and str.encode() call that produces OCI manifests, configs, indexes, and oci-layout files.

While OCI registries shall not distribute manifests not adherent to the spec, for reading use-case the the Robustness Principle is slected: be strict in what we produce, be lenient in what we accept.

Rather than writing a custom AST-based test with Python introspection, this leverages the existing Ruff linter rule PLW1514 (unspecified-encoding) to enforce the constraint.